### PR TITLE
automake 1.12 fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ Makefile
 Makefile.in
 aclocal.m4
 autom4te.cache/
+config/ar-lib
 config/compile
 config/config.guess
 config/config.sub

--- a/configure.ac
+++ b/configure.ac
@@ -21,6 +21,9 @@ AC_CONFIG_AUX_DIR(./config)
 # -I in ACLOCAL_AMFLAGS in the top-level Makefile.am.
 AC_CONFIG_MACRO_DIR(./config)
 
+m4_pattern_allow([AM_PROG_AR])
+AM_PROG_AR
+
 cat <<EOF
 
 ###


### PR DESCRIPTION
Newer linux distributions (e.g. Suse 12.2 ) have an updated automake version and require this fix.
